### PR TITLE
Feature/migrate points

### DIFF
--- a/scripts/demolition-man.coffee
+++ b/scripts/demolition-man.coffee
@@ -12,6 +12,7 @@
 #   hubot morality list - Show the list of immoral people.
 #   hubot morality show - Shows the current list of naughty words
 #   hubot morality add <word> - Adds a new word to the list, but only if the user has the 'morality' role
+#   hubot morality remove <word> - Removes a word from the list, but only if the user has the 'morality' role
 #
 # Author:
 #   whitman, jan0sch

--- a/scripts/demolition-man.coffee
+++ b/scripts/demolition-man.coffee
@@ -30,7 +30,7 @@ class moralityList
     @robot.brain.data.moralityList or= ['arse', 'ass', 'asshole', 'bastard', 'bloody', 'bitch', 'bugger', 'bollocks', 'bullshit', 'cock',
       'crap', 'crapping', 'cunt', 'damn', 'damnit', 'dick', 'douche', 'douchecanoe', 'fuck', 'fucked', 'fucking', 'fucknugget', 'goddam',
       'goddamn', 'piss', 'shit', 'shitcunt', 'twat', 'wank' ] # set the default list here
-      
+
     #set up all the responders, but only once we've got the list out of redis:
 #    @robot.brain.on 'loaded', (data) =>
 #      @robot.respond("/morality stats/i", @stats)
@@ -39,18 +39,18 @@ class moralityList
 #      @robot.respond("/morality add ?(.*)/i", @addWord)
 #      @robot.respond("/morality remove ?(.*)/i", @delWord)
 #      @rebuild  # sets up the regex for the current list, ready to fine people!
-    
+
 
   # gets the list of words
   words: ->
-    @robot.brain.data.moralityList 
+    @robot.brain.data.moralityList
 
   # adds a word to the list
   add: (word) ->
     @words().push(word)
 #    @robot.logger.debug 'starting rebuild'
     @robot.moralityList.rebuild()
-    
+
   # removes a word from the list
   del: (word) ->
     index = @words().indexOf(word)
@@ -58,25 +58,25 @@ class moralityList
       @words().splice(index, 1)
 #      @robot.logger.debug 'starting rebuild'
       @robot.moralityList.rebuild()
-    
-  #rebuild the regex and update the listener      
+
+  #rebuild the regex and update the listener
   rebuild: () ->
 #    @robot.logger.debug 'actually in rebuild()'
-    
-    # remove the old listener    
+
+    # remove the old listener
     if @robot.moralityList.listenerIdx > -1
       @robot.listeners.splice(@listenerIdx, 1)
-      
+
     # build the new regex
     regex = new RegExp('(?:^|\\s)(' + @robot.moralityList.words().join('|') + ')(?:\\b|$)', 'ig')
-    
+
     # add the listener to the robot
     @robot.hear regex, @robot.moralityList.fine
     @listenerIdx = @robot.listeners.length - 1
-        
+
   # does the actual fining of users
   fine: (msg) ->
-    username = msg.message.user.name   
+    username = msg.message.user.name
     users = @robot.brain.usersForFuzzyName(username)
     if users.length is 1
       user = users[0]
@@ -94,8 +94,8 @@ class moralityList
     response += "for a violation of the verbal morality statute."
 
     msg.send response
-      
-  # displays current statistics 
+
+  # displays current statistics
   # robot.respond /morality stats/i, (msg) ->
   stats: (msg) ->
     score = []
@@ -151,7 +151,7 @@ class moralityList
       response += "You're not allowed to know what the finable words are"
 
     msg.send response
-    
+
   # adds a new word to the list, rebuilding the regex/listener as we go:
   # robot.respond /morality add ?(.*)/i, (msg) ->
   addWord: (msg) ->

--- a/scripts/demolition-man.coffee
+++ b/scripts/demolition-man.coffee
@@ -194,8 +194,8 @@ module.exports = (robot) ->
   robot.respond "/morality stats/i", robot.moralityList.stats
   robot.respond "/morality list/i", robot.moralityList.list
   robot.respond "/morality show/i", robot.moralityList.show
-  robot.respond "/morality add ?(.*)/i", robot.moralityList.addWord
-  robot.respond "/morality remove ?(.*)/i", robot.moralityList.delWord
+  robot.respond "/morality add ([^\\s]+)$/i", robot.moralityList.addWord
+  robot.respond "/morality remove ([^\\s]+)$/i", robot.moralityList.delWord
   robot.moralityList.rebuild()  # sets up the regex for the current list, ready to fine people!
   
   #regex = new RegExp('(?:^|\\s)(' + robot.moralityList.words().join('|') + ')(?:\\b|$)', 'ig');

--- a/scripts/demolition-man.coffee
+++ b/scripts/demolition-man.coffee
@@ -188,6 +188,29 @@ class moralityList
 
     msg.send response
 
+  # set a users credit value
+  # /morality set credit ([^\\s]+) ([\\d]{1,4})/i, (msg) ->
+  updateCredit: (msg) ->
+    response = ""
+    user = msg.match[1].trim()
+    credit = msg.match[2].trim()
+
+    # is the user authorised to do so?
+    if @robot.auth.hasRole(msg.envelope.user,"admin")
+      users = @robot.brain.usersForFuzzyName(user)
+
+      if users.length is 1
+        user = users[0]
+
+        user.morality_credits = credit
+        response += "Set #{user.name}'s credit balance to #{credit}"
+      else
+        response += "User #{user} has not been found"
+    else
+      response += "You're not allowed to set the morality credits of a user"
+
+    msg.send response
+
 module.exports = (robot) ->
   # set everything up
   robot.moralityList = new moralityList(robot)
@@ -197,8 +220,8 @@ module.exports = (robot) ->
   robot.respond "/morality show/i", robot.moralityList.show
   robot.respond "/morality add ([^\\s]+)$/i", robot.moralityList.addWord
   robot.respond "/morality remove ([^\\s]+)$/i", robot.moralityList.delWord
+  robot.respond "/morality set credit ([^\\s]+) ([\\d]{1,4})/i", robot.moralityList.updateCredit
   robot.moralityList.rebuild()  # sets up the regex for the current list, ready to fine people!
-  
+
   #regex = new RegExp('(?:^|\\s)(' + robot.moralityList.words().join('|') + ')(?:\\b|$)', 'ig');
   #robot.hear regex, robot.moralityList.fine
-  


### PR DESCRIPTION
Allow the setting of credit points by admin users. 

This will allow us to migrate from the heroku powered funbot to a self-hosted version.